### PR TITLE
Add CLI v1-alpha

### DIFF
--- a/episimlab/partition/partition.py
+++ b/episimlab/partition/partition.py
@@ -181,6 +181,7 @@ class Partition2Contact:
 
         return daily_pop
 
+    @profiler()
     def dask_partition(self):
 
         total = self.population_totals()

--- a/episimlab/setup/counts.py
+++ b/episimlab/setup/counts.py
@@ -1,3 +1,4 @@
+import logging
 import pandas as pd
 import xsimlab as xs
 import xarray as xr
@@ -5,6 +6,7 @@ from .coords import InitDefaultCoords
 
 from ..apply_counts_delta import ApplyCountsDelta
 
+logging.basicConfig(level=logging.DEBUG)
 
 
 @xs.process
@@ -77,12 +79,17 @@ class InitCountsFromCensusCSV(InitDefaultCounts):
         da.loc[dict(compartment='S', risk_group='low')] = dac
         self.counts = da
         self.set_ia()
-    
+
+        # warning if detects no infected
+        if self.counts.loc[dict(compartment='Ia')].sum() < 1.:
+            logging.warning(f"Population of Ia compartment is less than 1. Did " +
+                          "you forget to set infected compartment?")
+
     def set_ia(self):
         """Sets Ia compartment to 50 for all vertices.
         """
         self.counts.loc[dict(compartment='Ia', risk_group='low')] = 50.
-    
+
     def read_census_csv(self) -> xr.DataArray:
         df = pd.read_csv(self.census_counts_csv)
         assert not df.isna().any().any(), ('found null values in df', df.isna().any())

--- a/scripts/20210512_partition_model.yaml
+++ b/scripts/20210512_partition_model.yaml
@@ -1,5 +1,10 @@
+# integer seed for RNG
 seed_entropy: 12345
-sto_toggle: -1
+
+# when to turn stochastic on. -1 for never. 0 for always
+sto_toggle: 0
+
+# epi params
 symp_h_ratio_w_risk:
     - [0.0002791, 0.0002146, 0.0132154, 0.0285634, 0.0338733]
     - [0.002791, 0.002146, 0.132154, 0.285634, 0.338733]

--- a/scripts/20210615_partition_model.py
+++ b/scripts/20210615_partition_model.py
@@ -45,11 +45,7 @@ def partition_from_csv(**opts) -> xr.Dataset:
     )
     # breakpoint()
     out_ds = run_model(input_ds, model)
-    # return out_ds
-
-    # visualize
-    xr_viz(out_ds['apply_counts_delta__counts'], isel=dict(vertex=1),
-           sel=dict(compartment='Ia'))
+    return out_ds
 
 
 def xr_viz(data_array, sel=dict(), isel=dict(), timeslice=slice(0, None),

--- a/scripts/20210615_partition_model.py
+++ b/scripts/20210615_partition_model.py
@@ -110,7 +110,7 @@ def run_model(input_ds: xr.Dataset, model: xs.Model) -> xr.Dataset:
 
 
 def main(func_name, **opts):
-    globals()[func_name](**opts)
+    partition_from_csv(**opts)
 
 
 def get_opts() -> dict:
@@ -118,9 +118,9 @@ def get_opts() -> dict:
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("-v", "--verbose", action="store_true", required=False, help="")
     # parser.add_argument('', type=argparse.FileType('r'), help="")
-    parser.add_argument("-f", "--func-name", type=str, required=False, help="",
-                        choices=['partition_from_nc', 'partition_from_csv'],
-                        default='partition_from_csv')
+    # parser.add_argument("-f", "--func-name", type=str, required=False, help="",
+    #                     choices=['partition_from_nc', 'partition_from_csv'],
+    #                     default='partition_from_csv')
 
     parser.add_argument('--config-fp', default='scripts/20210512_partition_model.yaml', 
                         type=str, required=False, help='path to YAML configuration file')

--- a/scripts/20210615_partition_model.py
+++ b/scripts/20210615_partition_model.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+import argparse
+import pandas as pd
+import xarray as xr
+import xsimlab as xs
+from matplotlib import pyplot as plt
+from episimlab import apply_counts_delta
+from episimlab.models import basic
+from episimlab.partition.partition import Partition2Contact
+from episimlab.setup import coords, counts
+
+
+def partition_from_csv():
+    model = (basic
+             .partition()
+             .drop_processes(['setup_beta'])
+             .update_processes(dict(
+                 get_contact_xr=Partition2Contact, 
+             ))
+            )
+    # breakpoint()
+
+    input_vars = {
+        'config_fp': 'scripts/20210512_partition_model.yaml',
+        'travel_fp': 'data/20200311_travel.csv',
+        'contacts_fp': 'data/polymod_contacts.csv',
+        'census_counts_csv': 'data/2019_zcta_pop_5_age_groups.csv',
+        'beta': 1.
+    }
+    # Reindex with `process__variable` keys
+    input_vars_with_proc = dict()
+    for proc, var in model.input_vars:
+        assert var in input_vars, f"model requires var {var}, but could not find in input var dict"
+        input_vars_with_proc[f"{proc}__{var}"] = input_vars[var]
+    
+    # run model
+    input_ds = xs.create_setup(
+        model=model,
+        clocks={
+            'step': pd.date_range(start='3/11/2020', end='3/13/2020', freq='24H')
+        },
+        input_vars=input_vars_with_proc,
+        output_vars=dict(apply_counts_delta__counts='step')
+    )
+    # breakpoint()
+    out_ds = run_model(input_ds, model)
+
+
+
+def partition_from_nc():
+    model = (basic
+             .partition()
+             .drop_processes(['setup_beta'])
+             .update_processes(dict(setup_counts=counts.InitCountsFromCensusCSV))
+            )
+
+    input_vars = {
+        'config_fp': 'scripts/20210512_partition_model.yaml',
+        'contact_da_fp': 'tests/data/20200311_contact_matrix.nc',
+        'census_counts_csv': 'data/2019_zcta_pop_5_age_groups.csv',
+        'beta': 1.
+    }
+    # Reindex with `process__variable` keys
+    input_vars_with_proc = dict()
+    for proc, var in model.input_vars:
+        assert var in input_vars, f"model requires var {var}, but could not find in input var dict"
+        input_vars_with_proc[f"{proc}__{var}"] = input_vars[var]
+    
+    # run model
+    input_ds = xs.create_setup(
+        model=model,
+        clocks={
+            'step': pd.date_range(start='3/11/2020', end='6/1/2020', freq='24H')
+        },
+        input_vars=input_vars_with_proc,
+        output_vars=dict(apply_counts_delta__counts='step')
+    )
+    # breakpoint()
+    out_ds = run_model(input_ds, model)
+
+
+def run_model(input_ds: xr.Dataset, model: xs.Model) -> xr.Dataset:
+    out_ds = input_ds.xsimlab.run(model=model, decoding=dict(mask_and_scale=False))
+    cts = out_ds['apply_counts_delta__counts']
+    # breakpoint()
+
+    # plot
+    cts.sum(['age_group', 'risk_group', 'vertex']).loc[dict()].plot.line(x='step')
+    plt.show()
+
+    return out_ds
+
+
+def main(func_name, **opts):
+    globals()[func_name]()
+
+
+def get_opts() -> dict:
+    """Get options from command line"""
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument("-v", "--verbose", action="store_true", required=False, help="")
+    # parser.add_argument('file', type=argparse.FileType('r'), help="")
+    parser.add_argument("-f", "--func-name", type=str, required=True, help="",
+                        choices=['partition_from_nc', 'partition_from_csv'])
+    return vars(parser.parse_args())
+
+
+if __name__ == '__main__':
+    opts = get_opts()
+    main(**opts)


### PR DESCRIPTION
- Adds script `scripts/20210615_partition_model.py` that implements a minimum viable partitioning model.
- Basic argparse CLI that takes paths to
    - Configuration YAML file
    - Travel CSV file
    - Contacts CSV file

## Usage

```bash
$ PYTHONPATH='.' poetry run python scripts/20210615_partition_model.py --help
usage: 20210615_partition_model.py [-h] [-v] [--config-fp CONFIG_FP] [--travel-fp TRAVEL_FP] [--contacts-fp CONTACTS_FP] [--census-counts-csv CENSUS_COUNTS_CSV]
                                   [--beta BETA] [--initial-ia INITIAL_IA] [--start-date START_DATE] [--end-date END_DATE]

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose
  --config-fp CONFIG_FP
                        path to YAML configuration file
  --travel-fp TRAVEL_FP
                        path to travel.csv file
  --contacts-fp CONTACTS_FP
                        path to contacts.csv file
  --census-counts-csv CENSUS_COUNTS_CSV
                        path to file containing populations of ZCTAs
  --beta BETA           global transmission parameter
  --initial-ia INITIAL_IA
                        initial size of the Ia compartment (low risk only)
  --start-date START_DATE
                        starting date for the simulation, in string format of pandas.date_range
  --end-date END_DATE   end date for the simulation, in string format of pandas.date_range
```